### PR TITLE
scan env for HTTP_GATEWAY

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -7,7 +7,7 @@ Defaults are localhost, 6379, and no auth.
 Current votecounts are displayed by monitoring the `demo:votes` hash in redis.
 
 Votes are posted to the votes topic in Riff via the http-gateway service configured 
-at `HTTP_GATEWAY_SERVICE_HOST` and `HTTP_GATEWAY_SERVICE_PORT` (otionally prefixed with
+at `HTTP_GATEWAY_SERVICE_HOST` and `HTTP_GATEWAY_SERVICE_PORT` (optionally prefixed with
 a helm deploy name). If no gateway is found, votes are incremented redis directly. 
 
 Function replica counts are monitored from redis hash `demo:function-replicas`.

--- a/ui/README.md
+++ b/ui/README.md
@@ -4,9 +4,11 @@ nodejs socket.io server backed by redis
 The server looks for redis using environment variables `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`.
 Defaults are localhost, 6379, and no auth.
 
+Current votecounts are displayed by monitoring the `demo:votes` hash in redis.
+
 Votes are posted to the votes topic in Riff via the http-gateway service configured 
-at `HTTP_GATEWAY_SERVICE_HOST` and `HTTP_GATEWAY_SERVICE_PORT`. Current votecounts are
-displayed by monitoring the `demo:votes` hash in redis.
+at `HTTP_GATEWAY_SERVICE_HOST` and `HTTP_GATEWAY_SERVICE_PORT` (otionally prefixed with
+a helm deploy name). If no gateway is found, votes are incremented redis directly. 
 
 Function replica counts are monitored from redis hash `demo:function-replicas`.
 

--- a/ui/scripts/localenv
+++ b/ui/scripts/localenv
@@ -4,6 +4,6 @@ export REDIS_HOST=$(minikube ip)
 export REDIS_PASSWORD=$(kubectl get secret --namespace default counters-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
 
 export HTTP_GATEWAY_SERVICE_HOST=$(minikube ip)
-export HTTP_GATEWAY_SERVICE_PORT=$(kubectl get svc demo-riff-http-gateway -o jsonpath='{.spec.ports[0].nodePort}')
+export HTTP_GATEWAY_SERVICE_PORT=$(kubectl get svc -l component=http-gateway -o jsonpath='{.items[0].spec.ports[?(@.name == "http")].nodePort}')
 
 env | grep -e HTTP_GATEWAY -e REDIS

--- a/ui/scripts/localenv
+++ b/ui/scripts/localenv
@@ -4,6 +4,6 @@ export REDIS_HOST=$(minikube ip)
 export REDIS_PASSWORD=$(kubectl get secret --namespace default counters-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
 
 export HTTP_GATEWAY_SERVICE_HOST=$(minikube ip)
-export HTTP_GATEWAY_SERVICE_PORT=$(kubectl get svc http-gateway -o jsonpath='{.spec.ports[0].nodePort}')
+export HTTP_GATEWAY_SERVICE_PORT=$(kubectl get svc demo-riff-http-gateway -o jsonpath='{.spec.ports[0].nodePort}')
 
 env | grep -e HTTP_GATEWAY -e REDIS


### PR DESCRIPTION
updated server to scan environment for `*_HTTP_GATEWAY_SERVICE_HOST`
this should make it work independent of helm name used

also turned off verbose logging of the vote POSTs