### PR TITLE
use projectriff/node-function-invoker:0.0.2-s1p from docker

### DIFF
--- a/functions/redis-writer/Dockerfile
+++ b/functions/redis-writer/Dockerfile
@@ -1,4 +1,4 @@
-FROM projectriff/node-function-invoker:0.0.2-snapshot
+FROM projectriff/node-function-invoker:0.0.2-s1p
 RUN npm install redis@2.8.0 --production
 ENV FUNCTION_URI /functions/function.js
 ADD redis-writer.js ${FUNCTION_URI}

--- a/functions/vote-counter/Dockerfile
+++ b/functions/vote-counter/Dockerfile
@@ -1,4 +1,4 @@
-FROM projectriff/node-function-invoker:0.0.2-snapshot
+FROM projectriff/node-function-invoker:0.0.2-s1p
 RUN npm install redis@2.8.0 --production
 ENV FUNCTION_URI /functions/function.js
 ADD vote-counter.js ${FUNCTION_URI}


### PR DESCRIPTION
would make helm demo easier if we fixed these to point to the new docker images on dockerhub